### PR TITLE
ETF Service with UNDY (Notre Dame Dorm ETF)

### DIFF
--- a/bots/bot_runner.cpp
+++ b/bots/bot_runner.cpp
@@ -42,20 +42,58 @@ int main(int argc, char* argv[]) {
     }
 
     std::vector<symbol_definition> symbols = {
-        {1, 10, 1, 1000, 10000000, 0}, // GOLD
-        {2, 5, 1, 1000, 10000000, 0}, // BLUE
+        {1, 10, 1, 1000, 10000000, 0},  // GOLD
+        {2, 5, 1, 1000, 10000000, 0},   // BLUE
+        // UNDY ETF underlying components (Notre Dame dorms)
+        // Men's dorms
+        {3, 5, 1, 1000, 10000000, 0},   // KNAN - Keenan Hall
+        {4, 5, 1, 1000, 10000000, 0},   // STED - St. Edward's Hall
+        {5, 5, 1, 1000, 10000000, 0},   // FISH - Fisher Hall
+        {6, 5, 1, 1000, 10000000, 0},   // DILN - Dillon Hall
+        {7, 5, 1, 1000, 10000000, 0},   // SORN - Sorin Hall
+        // Women's dorms
+        {8, 5, 1, 1000, 10000000, 0},   // RYAN - Ryan Hall
+        {9, 5, 1, 1000, 10000000, 0},   // LYON - Lyons Hall
+        {10, 5, 1, 1000, 10000000, 0},  // WLSH - Walsh Hall
+        {11, 5, 1, 1000, 10000000, 0},  // LEWI - Lewis Hall
+        {12, 5, 1, 1000, 10000000, 0},  // BDIN - Badin Hall
+        // ETF (1 UNDY = 1 share of each underlying)
+        {13, 10, 1, 1000, 10000000, 0}, // UNDY - Notre Dame Dorm ETF
     };
 
     std::vector<ndfex::bots::FairValue*> fair_values{
-        new ndfex::bots::RandomWalkFairValue(1200, symbols[0]),
-        new ndfex::bots::RandomWalkFairValue(900, symbols[1]),
+        new ndfex::bots::RandomWalkFairValue(1200, symbols[0]),  // GOLD
+        new ndfex::bots::RandomWalkFairValue(900, symbols[1]),   // BLUE
+        // Dorm underlyings - prices around 500-700
+        new ndfex::bots::RandomWalkFairValue(550, symbols[2]),   // KNAN
+        new ndfex::bots::RandomWalkFairValue(520, symbols[3]),   // STED
+        new ndfex::bots::RandomWalkFairValue(580, symbols[4]),   // FISH
+        new ndfex::bots::RandomWalkFairValue(510, symbols[5]),   // DILN
+        new ndfex::bots::RandomWalkFairValue(600, symbols[6]),   // SORN
+        new ndfex::bots::RandomWalkFairValue(530, symbols[7]),   // RYAN
+        new ndfex::bots::RandomWalkFairValue(540, symbols[8]),   // LYON
+        new ndfex::bots::RandomWalkFairValue(560, symbols[9]),   // WLSH
+        new ndfex::bots::RandomWalkFairValue(570, symbols[10]),  // LEWI
+        new ndfex::bots::RandomWalkFairValue(590, symbols[11]),  // BDIN
+        // UNDY ETF - fair value = sum of underlyings (~5550)
+        new ndfex::bots::RandomWalkFairValue(5550, symbols[12]), // UNDY
     };
 
     // create market data client
     ndfex::bots::MDClient md_client(mcast_ip, 12345, snapshot_ip, 12345, mcast_bind_ip, logger);
     md_client.wait_for_snapshot();
 
-    std::vector<std::vector<int32_t>> variances = { {0, 0}, {1, 1}, {-1, -1}, {1, 0}, {2, 0}, {0, 2}, {3, 0} };
+    // Variances for each market maker (one value per symbol)
+    // Format: {GOLD, BLUE, KNAN, STED, FISH, DILN, SORN, RYAN, LYON, WLSH, LEWI, BDIN, UNDY}
+    std::vector<std::vector<int32_t>> variances = {
+        {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},      // Neutral
+        {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 10},     // Slightly bullish
+        {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -10},  // Slightly bearish
+        {1, 0, 2, 0, 1, 0, 2, 0, 1, 0, 2, 0, 5},      // Mixed
+        {2, 0, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 10},     // Alternating
+        {0, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 5},      // Dorm focused
+        {3, 0, -1, 1, -1, 1, -1, 1, -1, 1, -1, 1, 0}, // Contrarian
+    };
 
     uint32_t last_order_id = 1;
     std::vector<ndfex::bots::FairValueMarketMaker> market_makers;

--- a/etf_service/app.py
+++ b/etf_service/app.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""
+ETF Service - Main Application
+
+Provides:
+1. REST API for ETF create/redeem operations
+2. WebSocket server for dashboard (replaces web_data.cpp)
+3. Position tracking via clearing multicast + ETF adjustments
+
+Usage:
+    python app.py <md_mcast_ip> <clearing_mcast_ip> <mcast_bind_ip> [--rest-port PORT] [--ws-port PORT]
+"""
+
+import argparse
+import asyncio
+import json
+import signal
+import sys
+import threading
+import time
+from functools import wraps
+
+from flask import Flask, jsonify, request, render_template
+
+# Import with proper handling for running as main
+try:
+    from config import (
+        SYMBOLS, ETF_SYMBOL, UNDERLYING_SYMBOLS,
+        MD_MCAST_PORT, CLEARING_MCAST_PORT, WEBSOCKET_PORT, REST_PORT,
+        get_ticker
+    )
+    from clearing_client import ClearingClient
+    from md_client import MDClient
+    from position_ledger import PositionLedger
+except ImportError:
+    # Running from parent directory
+    from etf_service.config import (
+        SYMBOLS, ETF_SYMBOL, UNDERLYING_SYMBOLS,
+        MD_MCAST_PORT, CLEARING_MCAST_PORT, WEBSOCKET_PORT, REST_PORT,
+        get_ticker
+    )
+    from etf_service.clearing_client import ClearingClient
+    from etf_service.md_client import MDClient
+    from etf_service.position_ledger import PositionLedger
+
+# Try to import websockets, provide helpful error if missing
+try:
+    import websockets
+except ImportError:
+    print("ERROR: websockets package not installed. Run: pip install websockets")
+    sys.exit(1)
+
+
+# Global instances (initialized in main)
+clearing_client: ClearingClient = None
+md_client: MDClient = None
+ledger: PositionLedger = None
+
+# Flask app
+app = Flask(__name__)
+
+
+# ============================================================================
+# REST API Endpoints
+# ============================================================================
+
+@app.route('/health')
+def health():
+    """Health check endpoint."""
+    return jsonify({"status": "ok", "service": "etf_service"})
+
+
+@app.route('/symbols')
+def get_symbols():
+    """Get all symbol definitions."""
+    return jsonify({
+        "symbols": [
+            {"id": sym_id, **info}
+            for sym_id, info in SYMBOLS.items()
+        ],
+        "etf_symbol": ETF_SYMBOL,
+        "underlying_symbols": UNDERLYING_SYMBOLS,
+    })
+
+
+@app.route('/positions/<int:client_id>')
+def get_positions(client_id: int):
+    """Get all positions for a client."""
+    positions = ledger.get_all_positions(client_id)
+    return jsonify({
+        "client_id": client_id,
+        "positions": {
+            get_ticker(sym): qty
+            for sym, qty in positions.items()
+        }
+    })
+
+
+@app.route('/positions/<int:client_id>/<int:symbol>')
+def get_position(client_id: int, symbol: int):
+    """Get position for a specific client/symbol."""
+    position = ledger.get_position(client_id, symbol)
+    return jsonify({
+        "client_id": client_id,
+        "symbol": symbol,
+        "ticker": get_ticker(symbol),
+        "position": position,
+    })
+
+
+@app.route('/create', methods=['POST'])
+def create_etf():
+    """
+    Create UNDY ETF shares from underlying positions.
+    
+    Request body:
+        {"client_id": int, "amount": int}
+    
+    Response:
+        {"success": bool, "message": str, "undy_balance": int}
+    """
+    data = request.get_json()
+    if not data:
+        return jsonify({"success": False, "message": "Missing JSON body"}), 400
+    
+    client_id = data.get("client_id")
+    amount = data.get("amount")
+    
+    if client_id is None or amount is None:
+        return jsonify({"success": False, "message": "Missing client_id or amount"}), 400
+    
+    try:
+        client_id = int(client_id)
+        amount = int(amount)
+    except (ValueError, TypeError):
+        return jsonify({"success": False, "message": "Invalid client_id or amount"}), 400
+    
+    success, message = ledger.create_etf(client_id, amount)
+    undy_balance = ledger.get_position(client_id, ETF_SYMBOL)
+    
+    status_code = 200 if success else 400
+    return jsonify({
+        "success": success,
+        "message": message,
+        "undy_balance": undy_balance,
+    }), status_code
+
+
+@app.route('/redeem', methods=['POST'])
+def redeem_etf():
+    """
+    Redeem UNDY ETF shares back to underlying positions.
+    
+    Request body:
+        {"client_id": int, "amount": int}
+    
+    Response:
+        {"success": bool, "message": str, "undy_balance": int}
+    """
+    data = request.get_json()
+    if not data:
+        return jsonify({"success": False, "message": "Missing JSON body"}), 400
+    
+    client_id = data.get("client_id")
+    amount = data.get("amount")
+    
+    if client_id is None or amount is None:
+        return jsonify({"success": False, "message": "Missing client_id or amount"}), 400
+    
+    try:
+        client_id = int(client_id)
+        amount = int(amount)
+    except (ValueError, TypeError):
+        return jsonify({"success": False, "message": "Invalid client_id or amount"}), 400
+    
+    success, message = ledger.redeem_etf(client_id, amount)
+    undy_balance = ledger.get_position(client_id, ETF_SYMBOL)
+    
+    status_code = 200 if success else 400
+    return jsonify({
+        "success": success,
+        "message": message,
+        "undy_balance": undy_balance,
+    }), status_code
+
+
+@app.route('/history')
+def get_history():
+    """Get ETF create/redeem history."""
+    return jsonify({"history": ledger.get_history()})
+
+
+@app.route('/')
+def index():
+    """Simple web UI for ETF operations."""
+    return render_template('etf.html', symbols=SYMBOLS, etf_symbol=ETF_SYMBOL)
+
+
+# ============================================================================
+# WebSocket Server (replaces web_data.cpp)
+# ============================================================================
+
+async def websocket_handler(websocket, path):
+    """
+    Handle WebSocket connections for the dashboard.
+    Sends periodic snapshots in the same format as web_data.cpp.
+    """
+    print(f"WebSocket: New connection from {websocket.remote_address}")
+    try:
+        while True:
+            # Build snapshot in the format expected by clearing-web-app
+            snapshot = build_dashboard_snapshot()
+            await websocket.send(json.dumps(snapshot))
+            await asyncio.sleep(0.1)  # 100ms interval
+    except websockets.exceptions.ConnectionClosed:
+        print(f"WebSocket: Connection closed from {websocket.remote_address}")
+    except Exception as e:
+        print(f"WebSocket error: {e}")
+
+
+def build_dashboard_snapshot() -> dict:
+    """
+    Build the snapshot JSON in the format expected by clearing-web-app.
+    
+    Format:
+    {
+        "timestamp": int (nanoseconds),
+        "snapshot": [{"symbol": int, "best_bid": int, "best_ask": int}, ...],
+        "positions": [{"client_id": int, "symbol": int, "position": int, "pnl": float, "volume": int}, ...]
+    }
+    """
+    timestamp = time.time_ns()
+    
+    # Market data snapshot
+    snapshot = []
+    for symbol in SYMBOLS.keys():
+        bid_price, _ = md_client.get_best_bid(symbol)
+        ask_price, _ = md_client.get_best_ask(symbol)
+        snapshot.append({
+            "symbol": symbol,
+            "best_bid": bid_price,
+            "best_ask": ask_price,
+        })
+    
+    # Position data (includes ETF adjustments)
+    positions = ledger.get_all_clients_data(md_client)
+    
+    return {
+        "timestamp": timestamp,
+        "snapshot": snapshot,
+        "positions": positions,
+    }
+
+
+def run_websocket_server(port: int):
+    """Run the WebSocket server in its own event loop."""
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    
+    start_server = websockets.serve(websocket_handler, "0.0.0.0", port)
+    print(f"WebSocket server starting on port {port}")
+    
+    loop.run_until_complete(start_server)
+    loop.run_forever()
+
+
+# ============================================================================
+# Main
+# ============================================================================
+
+def main():
+    global clearing_client, md_client, ledger
+    
+    parser = argparse.ArgumentParser(description="NDFEX ETF Service")
+    parser.add_argument("md_mcast_ip", help="Market data multicast IP")
+    parser.add_argument("clearing_mcast_ip", help="Clearing multicast IP")
+    parser.add_argument("mcast_bind_ip", help="Local interface IP for multicast")
+    parser.add_argument("--rest-port", type=int, default=REST_PORT, help="REST API port")
+    parser.add_argument("--ws-port", type=int, default=WEBSOCKET_PORT, help="WebSocket port")
+    
+    args = parser.parse_args()
+    
+    print("=" * 60)
+    print("NDFEX ETF Service")
+    print("=" * 60)
+    print(f"Market Data:  {args.md_mcast_ip}:{MD_MCAST_PORT}")
+    print(f"Clearing:     {args.clearing_mcast_ip}:{CLEARING_MCAST_PORT}")
+    print(f"Bind IP:      {args.mcast_bind_ip}")
+    print(f"REST API:     http://0.0.0.0:{args.rest_port}")
+    print(f"WebSocket:    ws://0.0.0.0:{args.ws_port}")
+    print("=" * 60)
+    
+    # Initialize clients
+    clearing_client = ClearingClient(
+        mcast_ip=args.clearing_mcast_ip,
+        mcast_port=CLEARING_MCAST_PORT,
+        bind_ip=args.mcast_bind_ip
+    )
+    
+    md_client = MDClient(
+        mcast_ip=args.md_mcast_ip,
+        mcast_port=MD_MCAST_PORT,
+        bind_ip=args.mcast_bind_ip
+    )
+    
+    ledger = PositionLedger(clearing_client)
+    
+    # Start multicast listeners
+    clearing_client.start()
+    md_client.start()
+    
+    # Start WebSocket server in background thread
+    ws_thread = threading.Thread(
+        target=run_websocket_server,
+        args=(args.ws_port,),
+        daemon=True
+    )
+    ws_thread.start()
+    
+    # Handle shutdown gracefully
+    def shutdown(signum, frame):
+        print("\nShutting down...")
+        clearing_client.stop()
+        md_client.stop()
+        sys.exit(0)
+    
+    signal.signal(signal.SIGINT, shutdown)
+    signal.signal(signal.SIGTERM, shutdown)
+    
+    # Run Flask (blocking)
+    print(f"\nStarting REST API on port {args.rest_port}...")
+    app.run(host="0.0.0.0", port=args.rest_port, threaded=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/etf_service/clearing_client.py
+++ b/etf_service/clearing_client.py
@@ -1,0 +1,182 @@
+"""
+Clearing Multicast Client
+
+Listens to the clearing multicast feed and tracks positions/PnL for all clients.
+Ported from web_data/clearing_client.cpp.
+"""
+
+import socket
+import struct
+import threading
+from collections import defaultdict
+from typing import Dict, Tuple
+
+from config import CLEARING_MCAST_IP, CLEARING_MCAST_PORT, MCAST_BIND_IP
+
+# Clearing protocol constants (from matching_engine/clearing_protocol.H)
+CLEARING_MAGIC_NUMBER = 0x12345678
+
+# Message types
+MSG_TYPE_HEARTBEAT = 0
+MSG_TYPE_FILL = 1
+
+# Side
+SIDE_BUY = 1
+SIDE_SELL = 2
+
+# Struct formats (little-endian, packed)
+# clearing_header: magic(u64) + length(u16) + seq_num(u32) + msg_type(u8) = 15 bytes
+HEADER_FORMAT = "<QHIb"
+HEADER_SIZE = struct.calcsize(HEADER_FORMAT)
+
+# fill: header + client_id(u32) + symbol(u32) + quantity(u32) + price(i32) + side(u8)
+FILL_FORMAT = "<QHIbIIIib"
+FILL_SIZE = struct.calcsize(FILL_FORMAT)
+
+
+class ClearingClient:
+    """
+    Listens to clearing multicast and tracks positions, PnL, and volume.
+    Thread-safe for reading positions while processing incoming messages.
+    """
+
+    def __init__(self, mcast_ip: str = CLEARING_MCAST_IP, 
+                 mcast_port: int = CLEARING_MCAST_PORT,
+                 bind_ip: str = MCAST_BIND_IP):
+        self.mcast_ip = mcast_ip
+        self.mcast_port = mcast_port
+        self.bind_ip = bind_ip
+        
+        # Position tracking: {client_id: {symbol: value}}
+        self._lock = threading.Lock()
+        self._positions: Dict[int, Dict[int, int]] = defaultdict(lambda: defaultdict(int))
+        self._total_buy: Dict[int, Dict[int, int]] = defaultdict(lambda: defaultdict(int))
+        self._total_sell: Dict[int, Dict[int, int]] = defaultdict(lambda: defaultdict(int))
+        self._volume: Dict[int, Dict[int, int]] = defaultdict(lambda: defaultdict(int))
+        self._raw_pnl: Dict[int, Dict[int, int]] = defaultdict(lambda: defaultdict(int))
+        
+        self._last_seq_num = 0
+        self._socket = None
+        self._running = False
+        self._thread = None
+
+    def start(self):
+        """Start listening to clearing multicast in a background thread."""
+        self._socket = self._create_socket()
+        self._running = True
+        self._thread = threading.Thread(target=self._listen_loop, daemon=True)
+        self._thread.start()
+        print(f"ClearingClient: Listening on {self.mcast_ip}:{self.mcast_port}")
+
+    def stop(self):
+        """Stop the listener thread."""
+        self._running = False
+        if self._socket:
+            self._socket.close()
+        if self._thread:
+            self._thread.join(timeout=1.0)
+
+    def _create_socket(self) -> socket.socket:
+        """Create and configure the multicast socket."""
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+        except AttributeError:
+            pass  # SO_REUSEPORT not available on all platforms
+        
+        # Bind to multicast address
+        sock.bind((self.mcast_ip, self.mcast_port))
+        
+        # Join multicast group
+        mreq = struct.pack("4s4s", 
+                          socket.inet_aton(self.mcast_ip),
+                          socket.inet_aton(self.bind_ip))
+        sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+        
+        # Set timeout for clean shutdown
+        sock.settimeout(0.5)
+        
+        return sock
+
+    def _listen_loop(self):
+        """Main loop to receive and process clearing messages."""
+        while self._running:
+            try:
+                data, _ = self._socket.recvfrom(4096)
+                self._process_message(data)
+            except socket.timeout:
+                continue
+            except Exception as e:
+                if self._running:
+                    print(f"ClearingClient error: {e}")
+
+    def _process_message(self, data: bytes):
+        """Parse and process a clearing message."""
+        if len(data) < HEADER_SIZE:
+            return
+        
+        # Parse header
+        magic, length, seq_num, msg_type = struct.unpack_from(HEADER_FORMAT, data)
+        
+        if magic != CLEARING_MAGIC_NUMBER:
+            print(f"ClearingClient: Invalid magic number {magic:#x}")
+            return
+        
+        # Check sequence number
+        if self._last_seq_num != 0 and seq_num != self._last_seq_num + 1:
+            print(f"ClearingClient: Sequence gap - expected {self._last_seq_num + 1}, got {seq_num}")
+        self._last_seq_num = seq_num
+        
+        if msg_type == MSG_TYPE_FILL:
+            self._process_fill(data)
+        elif msg_type == MSG_TYPE_HEARTBEAT:
+            pass  # Heartbeat, nothing to do
+
+    def _process_fill(self, data: bytes):
+        """Process a fill message and update positions."""
+        if len(data) < FILL_SIZE:
+            return
+        
+        # Parse fill message
+        (magic, length, seq_num, msg_type, 
+         client_id, symbol, quantity, price, side) = struct.unpack_from(FILL_FORMAT, data)
+        
+        with self._lock:
+            if side == SIDE_BUY:
+                self._positions[client_id][symbol] += quantity
+                self._total_buy[client_id][symbol] += quantity * price
+            elif side == SIDE_SELL:
+                self._positions[client_id][symbol] -= quantity
+                self._total_sell[client_id][symbol] += quantity * price
+            
+            self._volume[client_id][symbol] += quantity
+            self._raw_pnl[client_id][symbol] = (
+                self._total_sell[client_id][symbol] - 
+                self._total_buy[client_id][symbol]
+            )
+
+    def get_position(self, client_id: int, symbol: int) -> int:
+        """Get position for a client/symbol pair."""
+        with self._lock:
+            return self._positions[client_id][symbol]
+
+    def get_positions(self) -> Dict[int, Dict[int, int]]:
+        """Get a copy of all positions."""
+        with self._lock:
+            return {cid: dict(syms) for cid, syms in self._positions.items()}
+
+    def get_raw_pnl(self) -> Dict[int, Dict[int, int]]:
+        """Get a copy of raw PnL data."""
+        with self._lock:
+            return {cid: dict(syms) for cid, syms in self._raw_pnl.items()}
+
+    def get_volume(self) -> Dict[int, Dict[int, int]]:
+        """Get a copy of volume data."""
+        with self._lock:
+            return {cid: dict(syms) for cid, syms in self._volume.items()}
+
+    def get_all_client_ids(self) -> set:
+        """Get set of all known client IDs."""
+        with self._lock:
+            return set(self._positions.keys())

--- a/etf_service/config.py
+++ b/etf_service/config.py
@@ -1,0 +1,54 @@
+"""
+ETF Service Configuration
+
+Symbol definitions and network settings for the NDFEX ETF service.
+"""
+
+# Network configuration (defaults, can be overridden via command line)
+CLEARING_MCAST_IP = "239.0.0.2"
+CLEARING_MCAST_PORT = 12346
+MD_MCAST_IP = "239.0.0.1"
+MD_MCAST_PORT = 12345
+SNAPSHOT_MCAST_IP = "239.0.0.3"
+MCAST_BIND_IP = "127.0.0.1"
+
+WEBSOCKET_PORT = 9002
+REST_PORT = 5000
+
+# Symbol definitions
+# Format: {symbol_id: {"ticker": str, "name": str, "tick_size": int}}
+SYMBOLS = {
+    1: {"ticker": "GOLD", "name": "Gold", "tick_size": 10},
+    2: {"ticker": "BLUE", "name": "Blue", "tick_size": 5},
+    # UNDY ETF underlying components (Notre Dame dorms)
+    # Men's dorms
+    3: {"ticker": "KNAN", "name": "Keenan Hall", "tick_size": 5},
+    4: {"ticker": "STED", "name": "St. Edward's Hall", "tick_size": 5},
+    5: {"ticker": "FISH", "name": "Fisher Hall", "tick_size": 5},
+    6: {"ticker": "DILN", "name": "Dillon Hall", "tick_size": 5},
+    7: {"ticker": "SORN", "name": "Sorin Hall", "tick_size": 5},
+    # Women's dorms
+    8: {"ticker": "RYAN", "name": "Ryan Hall", "tick_size": 5},
+    9: {"ticker": "LYON", "name": "Lyons Hall", "tick_size": 5},
+    10: {"ticker": "WLSH", "name": "Walsh Hall", "tick_size": 5},
+    11: {"ticker": "LEWI", "name": "Lewis Hall", "tick_size": 5},
+    12: {"ticker": "BDIN", "name": "Badin Hall", "tick_size": 5},
+    # ETF
+    13: {"ticker": "UNDY", "name": "Notre Dame Dorm ETF", "tick_size": 10},
+}
+
+# ETF configuration
+ETF_SYMBOL = 13  # UNDY
+UNDERLYING_SYMBOLS = [3, 4, 5, 6, 7, 8, 9, 10, 11, 12]  # All dorm symbols
+
+# Helper functions
+def get_ticker(symbol_id: int) -> str:
+    """Get ticker string for a symbol ID."""
+    return SYMBOLS.get(symbol_id, {}).get("ticker", f"SYM{symbol_id}")
+
+def get_symbol_id(ticker: str) -> int:
+    """Get symbol ID for a ticker string."""
+    for sym_id, info in SYMBOLS.items():
+        if info["ticker"] == ticker:
+            return sym_id
+    return -1

--- a/etf_service/md_client.py
+++ b/etf_service/md_client.py
@@ -1,0 +1,250 @@
+"""
+Market Data Multicast Client
+
+Listens to the market data feed and tracks best bid/offer for all symbols.
+Used to provide BBO data to the dashboard.
+"""
+
+import socket
+import struct
+import threading
+from collections import defaultdict
+from typing import Dict, Tuple, Optional
+
+from config import MD_MCAST_IP, MD_MCAST_PORT, MCAST_BIND_IP, SYMBOLS
+
+# Market data protocol constants (from market_data/md_protocol.H)
+# "GOIRISH!" as little-endian u64
+MD_MAGIC_NUMBER = int.from_bytes(b"GOIRISH!", "little")
+
+# Message types
+MSG_TYPE_HEARTBEAT = 0
+MSG_TYPE_NEW_ORDER = 1
+MSG_TYPE_DELETE_ORDER = 2
+MSG_TYPE_MODIFY_ORDER = 3
+MSG_TYPE_TRADE = 4
+MSG_TYPE_TRADE_SUMMARY = 5
+MSG_TYPE_SNAPSHOT_INFO = 6
+
+# Side
+SIDE_BUY = 1
+SIDE_SELL = 2
+
+# Struct formats (little-endian, packed)
+# md_header: magic(u64) + length(u16) + seq_num(u32) + timestamp(u64) + msg_type(u8) = 23 bytes
+HEADER_FORMAT = "<QHIQb"
+HEADER_SIZE = struct.calcsize(HEADER_FORMAT)
+
+# new_order: header + order_id(u64) + symbol(u32) + side(u8) + quantity(u32) + price(i32) + flags(u8)
+NEW_ORDER_FORMAT = "<QHIQbQIbIib"
+NEW_ORDER_SIZE = struct.calcsize(NEW_ORDER_FORMAT)
+
+# delete_order: header + order_id(u64)
+DELETE_ORDER_FORMAT = "<QHIQbQ"
+DELETE_ORDER_SIZE = struct.calcsize(DELETE_ORDER_FORMAT)
+
+# modify_order: header + order_id(u64) + side(u8) + quantity(u32) + price(i32)
+MODIFY_ORDER_FORMAT = "<QHIQbQbIi"
+MODIFY_ORDER_SIZE = struct.calcsize(MODIFY_ORDER_FORMAT)
+
+
+class Order:
+    """Represents a resting order in the book."""
+    __slots__ = ['order_id', 'symbol', 'side', 'quantity', 'price']
+    
+    def __init__(self, order_id: int, symbol: int, side: int, quantity: int, price: int):
+        self.order_id = order_id
+        self.symbol = symbol
+        self.side = side
+        self.quantity = quantity
+        self.price = price
+
+
+class MDClient:
+    """
+    Listens to market data multicast and maintains order book state.
+    Provides best bid/offer for each symbol.
+    """
+
+    def __init__(self, mcast_ip: str = MD_MCAST_IP,
+                 mcast_port: int = MD_MCAST_PORT,
+                 bind_ip: str = MCAST_BIND_IP):
+        self.mcast_ip = mcast_ip
+        self.mcast_port = mcast_port
+        self.bind_ip = bind_ip
+        
+        self._lock = threading.Lock()
+        # order_id -> Order
+        self._orders: Dict[int, Order] = {}
+        # symbol -> {price -> total_quantity} for bids (descending) and asks (ascending)
+        self._bids: Dict[int, Dict[int, int]] = defaultdict(lambda: defaultdict(int))
+        self._asks: Dict[int, Dict[int, int]] = defaultdict(lambda: defaultdict(int))
+        
+        self._last_seq_num = 0
+        self._socket = None
+        self._running = False
+        self._thread = None
+
+    def start(self):
+        """Start listening to market data in a background thread."""
+        self._socket = self._create_socket()
+        self._running = True
+        self._thread = threading.Thread(target=self._listen_loop, daemon=True)
+        self._thread.start()
+        print(f"MDClient: Listening on {self.mcast_ip}:{self.mcast_port}")
+
+    def stop(self):
+        """Stop the listener thread."""
+        self._running = False
+        if self._socket:
+            self._socket.close()
+        if self._thread:
+            self._thread.join(timeout=1.0)
+
+    def _create_socket(self) -> socket.socket:
+        """Create and configure the multicast socket."""
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+        except AttributeError:
+            pass
+        
+        sock.bind((self.mcast_ip, self.mcast_port))
+        
+        mreq = struct.pack("4s4s",
+                          socket.inet_aton(self.mcast_ip),
+                          socket.inet_aton(self.bind_ip))
+        sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+        sock.settimeout(0.5)
+        
+        return sock
+
+    def _listen_loop(self):
+        """Main loop to receive and process market data messages."""
+        while self._running:
+            try:
+                data, _ = self._socket.recvfrom(4096)
+                self._process_message(data)
+            except socket.timeout:
+                continue
+            except Exception as e:
+                if self._running:
+                    print(f"MDClient error: {e}")
+
+    def _process_message(self, data: bytes):
+        """Parse and process a market data message."""
+        if len(data) < HEADER_SIZE:
+            return
+        
+        magic, length, seq_num, timestamp, msg_type = struct.unpack_from(HEADER_FORMAT, data)
+        
+        if magic != MD_MAGIC_NUMBER:
+            return
+        
+        self._last_seq_num = seq_num
+        
+        if msg_type == MSG_TYPE_NEW_ORDER:
+            self._process_new_order(data)
+        elif msg_type == MSG_TYPE_DELETE_ORDER:
+            self._process_delete_order(data)
+        elif msg_type == MSG_TYPE_MODIFY_ORDER:
+            self._process_modify_order(data)
+        # Ignore trades and heartbeats for BBO purposes
+
+    def _process_new_order(self, data: bytes):
+        """Process a new order message."""
+        if len(data) < NEW_ORDER_SIZE:
+            return
+        
+        (magic, length, seq_num, timestamp, msg_type,
+         order_id, symbol, side, quantity, price, flags) = struct.unpack_from(NEW_ORDER_FORMAT, data)
+        
+        with self._lock:
+            order = Order(order_id, symbol, side, quantity, price)
+            self._orders[order_id] = order
+            
+            if side == SIDE_BUY:
+                self._bids[symbol][price] += quantity
+            else:
+                self._asks[symbol][price] += quantity
+
+    def _process_delete_order(self, data: bytes):
+        """Process a delete order message."""
+        if len(data) < DELETE_ORDER_SIZE:
+            return
+        
+        (magic, length, seq_num, timestamp, msg_type, order_id) = struct.unpack_from(DELETE_ORDER_FORMAT, data)
+        
+        with self._lock:
+            order = self._orders.pop(order_id, None)
+            if order:
+                if order.side == SIDE_BUY:
+                    self._bids[order.symbol][order.price] -= order.quantity
+                    if self._bids[order.symbol][order.price] <= 0:
+                        del self._bids[order.symbol][order.price]
+                else:
+                    self._asks[order.symbol][order.price] -= order.quantity
+                    if self._asks[order.symbol][order.price] <= 0:
+                        del self._asks[order.symbol][order.price]
+
+    def _process_modify_order(self, data: bytes):
+        """Process a modify order message."""
+        if len(data) < MODIFY_ORDER_SIZE:
+            return
+        
+        (magic, length, seq_num, timestamp, msg_type,
+         order_id, side, quantity, price) = struct.unpack_from(MODIFY_ORDER_FORMAT, data)
+        
+        with self._lock:
+            order = self._orders.get(order_id)
+            if order:
+                # Remove old quantity from book
+                if order.side == SIDE_BUY:
+                    self._bids[order.symbol][order.price] -= order.quantity
+                    if self._bids[order.symbol][order.price] <= 0:
+                        del self._bids[order.symbol][order.price]
+                else:
+                    self._asks[order.symbol][order.price] -= order.quantity
+                    if self._asks[order.symbol][order.price] <= 0:
+                        del self._asks[order.symbol][order.price]
+                
+                # Update order and add new quantity
+                order.side = side
+                order.quantity = quantity
+                order.price = price
+                
+                if side == SIDE_BUY:
+                    self._bids[order.symbol][price] += quantity
+                else:
+                    self._asks[order.symbol][price] += quantity
+
+    def get_best_bid(self, symbol: int) -> Tuple[int, int]:
+        """Get best bid price and quantity for a symbol. Returns (price, qty) or (0, 0)."""
+        with self._lock:
+            bids = self._bids.get(symbol, {})
+            if bids:
+                price = max(bids.keys())
+                return (price, bids[price])
+            return (0, 0)
+
+    def get_best_ask(self, symbol: int) -> Tuple[int, int]:
+        """Get best ask price and quantity for a symbol. Returns (price, qty) or (0, 0)."""
+        with self._lock:
+            asks = self._asks.get(symbol, {})
+            if asks:
+                price = min(asks.keys())
+                return (price, asks[price])
+            return (0, 0)
+
+    def get_bbo(self, symbol: int) -> Dict:
+        """Get best bid and offer for a symbol."""
+        bid_price, bid_qty = self.get_best_bid(symbol)
+        ask_price, ask_qty = self.get_best_ask(symbol)
+        return {
+            "symbol": symbol,
+            "best_bid": bid_price,
+            "bid_qty": bid_qty,
+            "best_ask": ask_price,
+            "ask_qty": ask_qty,
+        }

--- a/etf_service/position_ledger.py
+++ b/etf_service/position_ledger.py
@@ -1,0 +1,185 @@
+"""
+Position Ledger
+
+Combines clearing data with ETF create/redeem adjustments.
+This is the authoritative source for positions including ETF conversions.
+"""
+
+import threading
+from collections import defaultdict
+from typing import Dict, Tuple, List, Optional
+
+from config import ETF_SYMBOL, UNDERLYING_SYMBOLS, SYMBOLS, get_ticker
+from clearing_client import ClearingClient
+
+
+class PositionLedger:
+    """
+    Tracks positions by combining:
+    1. Real fills from clearing multicast (via ClearingClient)
+    2. ETF create/redeem adjustments (tracked locally)
+    
+    Thread-safe for concurrent access.
+    """
+
+    def __init__(self, clearing_client: ClearingClient):
+        self.clearing = clearing_client
+        
+        # ETF adjustments: {client_id: {symbol: adjustment}}
+        # Positive = credited, Negative = debited
+        self._lock = threading.Lock()
+        self._etf_adjustments: Dict[int, Dict[int, int]] = defaultdict(lambda: defaultdict(int))
+        
+        # Track create/redeem history for auditing
+        self._history: List[Dict] = []
+
+    def get_position(self, client_id: int, symbol: int) -> int:
+        """
+        Get the effective position for a client/symbol pair.
+        Returns clearing position + ETF adjustment.
+        """
+        clearing_pos = self.clearing.get_position(client_id, symbol)
+        with self._lock:
+            adjustment = self._etf_adjustments[client_id][symbol]
+        return clearing_pos + adjustment
+
+    def get_all_positions(self, client_id: int) -> Dict[int, int]:
+        """Get all positions for a client."""
+        result = {}
+        for symbol in SYMBOLS.keys():
+            pos = self.get_position(client_id, symbol)
+            if pos != 0:
+                result[symbol] = pos
+        return result
+
+    def create_etf(self, client_id: int, amount: int) -> Tuple[bool, str]:
+        """
+        Create ETF shares by exchanging underlying positions.
+        
+        Requires: `amount` shares of each underlying symbol.
+        Result: Debits underlyings, credits UNDY.
+        
+        Returns: (success, message)
+        """
+        if amount <= 0:
+            return False, "Amount must be positive"
+        
+        # Check if client has sufficient underlying positions
+        insufficient = []
+        for symbol in UNDERLYING_SYMBOLS:
+            pos = self.get_position(client_id, symbol)
+            if pos < amount:
+                ticker = get_ticker(symbol)
+                insufficient.append(f"{ticker}: have {pos}, need {amount}")
+        
+        if insufficient:
+            return False, f"Insufficient positions: {', '.join(insufficient)}"
+        
+        # Apply adjustments atomically
+        with self._lock:
+            for symbol in UNDERLYING_SYMBOLS:
+                self._etf_adjustments[client_id][symbol] -= amount
+            self._etf_adjustments[client_id][ETF_SYMBOL] += amount
+            
+            self._history.append({
+                "type": "create",
+                "client_id": client_id,
+                "amount": amount,
+            })
+        
+        return True, f"Created {amount} UNDY from underlying positions"
+
+    def redeem_etf(self, client_id: int, amount: int) -> Tuple[bool, str]:
+        """
+        Redeem ETF shares back to underlying positions.
+        
+        Requires: `amount` UNDY shares.
+        Result: Debits UNDY, credits underlyings.
+        
+        Returns: (success, message)
+        """
+        if amount <= 0:
+            return False, "Amount must be positive"
+        
+        # Check if client has sufficient UNDY
+        undy_pos = self.get_position(client_id, ETF_SYMBOL)
+        if undy_pos < amount:
+            return False, f"Insufficient UNDY: have {undy_pos}, need {amount}"
+        
+        # Apply adjustments atomically
+        with self._lock:
+            self._etf_adjustments[client_id][ETF_SYMBOL] -= amount
+            for symbol in UNDERLYING_SYMBOLS:
+                self._etf_adjustments[client_id][symbol] += amount
+            
+            self._history.append({
+                "type": "redeem",
+                "client_id": client_id,
+                "amount": amount,
+            })
+        
+        return True, f"Redeemed {amount} UNDY to underlying positions"
+
+    def get_etf_adjustments(self, client_id: int) -> Dict[int, int]:
+        """Get the ETF adjustments for a client (for debugging)."""
+        with self._lock:
+            return dict(self._etf_adjustments[client_id])
+
+    def get_all_clients_data(self, md_client=None) -> List[Dict]:
+        """
+        Get position data for all clients in the format expected by the dashboard.
+        
+        Returns list of dicts with: client_id, symbol, position, pnl, volume
+        """
+        result = []
+        
+        # Get all known client IDs from both clearing and adjustments
+        client_ids = self.clearing.get_all_client_ids()
+        with self._lock:
+            client_ids = client_ids | set(self._etf_adjustments.keys())
+        
+        clearing_positions = self.clearing.get_positions()
+        clearing_pnl = self.clearing.get_raw_pnl()
+        clearing_volume = self.clearing.get_volume()
+        
+        for client_id in client_ids:
+            for symbol in SYMBOLS.keys():
+                # Get effective position (clearing + adjustment)
+                clearing_pos = clearing_positions.get(client_id, {}).get(symbol, 0)
+                with self._lock:
+                    adjustment = self._etf_adjustments[client_id][symbol]
+                position = clearing_pos + adjustment
+                
+                # Get PnL and volume from clearing (adjustments don't affect these directly)
+                pnl = clearing_pnl.get(client_id, {}).get(symbol, 0)
+                volume = clearing_volume.get(client_id, {}).get(symbol, 0)
+                
+                # Calculate mark-to-market PnL if we have market data
+                if md_client and position != 0:
+                    if position > 0:
+                        bid_price, _ = md_client.get_best_bid(symbol)
+                        if bid_price > 0:
+                            pnl = pnl + (bid_price * position)
+                    else:
+                        ask_price, _ = md_client.get_best_ask(symbol)
+                        if ask_price > 0:
+                            pnl = pnl + (ask_price * position)
+                    # Subtract fees (0.05 per share traded)
+                    pnl -= volume * 0.05
+                
+                # Only include if there's any activity
+                if position != 0 or pnl != 0 or volume != 0:
+                    result.append({
+                        "client_id": client_id,
+                        "symbol": symbol,
+                        "position": position,
+                        "pnl": pnl,
+                        "volume": volume,
+                    })
+        
+        return result
+
+    def get_history(self) -> List[Dict]:
+        """Get create/redeem history."""
+        with self._lock:
+            return list(self._history)

--- a/etf_service/requirements.txt
+++ b/etf_service/requirements.txt
@@ -1,0 +1,2 @@
+flask>=2.0.0
+websockets>=10.0

--- a/etf_service/templates/etf.html
+++ b/etf_service/templates/etf.html
@@ -1,0 +1,388 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>NDFEX ETF Service</title>
+    <style>
+        :root {
+            --bg-primary: #0d1117;
+            --bg-secondary: #161b22;
+            --bg-tertiary: #21262d;
+            --text-primary: #c9d1d9;
+            --text-secondary: #8b949e;
+            --accent-gold: #d4a843;
+            --accent-green: #3fb950;
+            --accent-red: #f85149;
+            --accent-blue: #58a6ff;
+            --border: #30363d;
+        }
+        
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+        
+        body {
+            font-family: 'JetBrains Mono', 'Fira Code', monospace;
+            background: var(--bg-primary);
+            color: var(--text-primary);
+            min-height: 100vh;
+            padding: 2rem;
+        }
+        
+        .container {
+            max-width: 900px;
+            margin: 0 auto;
+        }
+        
+        header {
+            text-align: center;
+            margin-bottom: 3rem;
+            padding-bottom: 2rem;
+            border-bottom: 1px solid var(--border);
+        }
+        
+        h1 {
+            font-size: 2.5rem;
+            font-weight: 700;
+            color: var(--accent-gold);
+            letter-spacing: 0.05em;
+            margin-bottom: 0.5rem;
+        }
+        
+        h1 span {
+            color: var(--text-secondary);
+            font-weight: 400;
+        }
+        
+        .subtitle {
+            color: var(--text-secondary);
+            font-size: 0.9rem;
+        }
+        
+        .section {
+            background: var(--bg-secondary);
+            border: 1px solid var(--border);
+            border-radius: 8px;
+            padding: 1.5rem;
+            margin-bottom: 1.5rem;
+        }
+        
+        .section h2 {
+            font-size: 1rem;
+            color: var(--accent-blue);
+            margin-bottom: 1rem;
+            text-transform: uppercase;
+            letter-spacing: 0.1em;
+        }
+        
+        .form-group {
+            display: flex;
+            gap: 1rem;
+            margin-bottom: 1rem;
+            align-items: flex-end;
+        }
+        
+        .form-field {
+            flex: 1;
+        }
+        
+        label {
+            display: block;
+            font-size: 0.75rem;
+            color: var(--text-secondary);
+            margin-bottom: 0.5rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+        
+        input {
+            width: 100%;
+            padding: 0.75rem 1rem;
+            background: var(--bg-tertiary);
+            border: 1px solid var(--border);
+            border-radius: 4px;
+            color: var(--text-primary);
+            font-family: inherit;
+            font-size: 1rem;
+        }
+        
+        input:focus {
+            outline: none;
+            border-color: var(--accent-blue);
+        }
+        
+        .btn-group {
+            display: flex;
+            gap: 0.75rem;
+        }
+        
+        button {
+            padding: 0.75rem 1.5rem;
+            border: none;
+            border-radius: 4px;
+            font-family: inherit;
+            font-size: 0.9rem;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.15s ease;
+        }
+        
+        button.create {
+            background: var(--accent-green);
+            color: #000;
+        }
+        
+        button.redeem {
+            background: var(--accent-gold);
+            color: #000;
+        }
+        
+        button:hover {
+            transform: translateY(-1px);
+            filter: brightness(1.1);
+        }
+        
+        button:active {
+            transform: translateY(0);
+        }
+        
+        .result {
+            margin-top: 1rem;
+            padding: 1rem;
+            border-radius: 4px;
+            font-size: 0.9rem;
+            display: none;
+        }
+        
+        .result.success {
+            background: rgba(63, 185, 80, 0.15);
+            border: 1px solid var(--accent-green);
+            color: var(--accent-green);
+            display: block;
+        }
+        
+        .result.error {
+            background: rgba(248, 81, 73, 0.15);
+            border: 1px solid var(--accent-red);
+            color: var(--accent-red);
+            display: block;
+        }
+        
+        .positions-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+            gap: 0.75rem;
+        }
+        
+        .position-card {
+            background: var(--bg-tertiary);
+            border: 1px solid var(--border);
+            border-radius: 4px;
+            padding: 0.75rem;
+            text-align: center;
+        }
+        
+        .position-card .ticker {
+            font-size: 0.85rem;
+            font-weight: 600;
+            color: var(--accent-blue);
+            margin-bottom: 0.25rem;
+        }
+        
+        .position-card .qty {
+            font-size: 1.25rem;
+            font-weight: 700;
+        }
+        
+        .position-card .qty.positive {
+            color: var(--accent-green);
+        }
+        
+        .position-card .qty.negative {
+            color: var(--accent-red);
+        }
+        
+        .position-card .qty.zero {
+            color: var(--text-secondary);
+        }
+        
+        .position-card.etf {
+            border-color: var(--accent-gold);
+            background: rgba(212, 168, 67, 0.1);
+        }
+        
+        .position-card.etf .ticker {
+            color: var(--accent-gold);
+        }
+        
+        .info {
+            font-size: 0.8rem;
+            color: var(--text-secondary);
+            margin-top: 1rem;
+            padding: 1rem;
+            background: var(--bg-tertiary);
+            border-radius: 4px;
+        }
+        
+        .info code {
+            background: var(--bg-primary);
+            padding: 0.2rem 0.4rem;
+            border-radius: 3px;
+            color: var(--accent-gold);
+        }
+        
+        #loading {
+            color: var(--text-secondary);
+            font-style: italic;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <header>
+            <h1>UNDY <span>ETF Service</span></h1>
+            <p class="subtitle">Notre Dame Dorm Exchange-Traded Fund</p>
+        </header>
+        
+        <div class="section">
+            <h2>ETF Operations</h2>
+            <div class="form-group">
+                <div class="form-field">
+                    <label for="client_id">Client ID</label>
+                    <input type="number" id="client_id" placeholder="e.g., 1" min="1">
+                </div>
+                <div class="form-field">
+                    <label for="amount">Amount</label>
+                    <input type="number" id="amount" placeholder="e.g., 10" min="1">
+                </div>
+            </div>
+            <div class="btn-group">
+                <button class="create" onclick="createETF()">Create UNDY</button>
+                <button class="redeem" onclick="redeemETF()">Redeem UNDY</button>
+            </div>
+            <div id="result" class="result"></div>
+            
+            <div class="info">
+                <strong>ETF Composition:</strong> 1 UNDY = 1 share each of 
+                <code>KNAN</code> <code>STED</code> <code>FISH</code> <code>DILN</code> <code>SORN</code>
+                <code>RYAN</code> <code>LYON</code> <code>WLSH</code> <code>LEWI</code> <code>BDIN</code>
+            </div>
+        </div>
+        
+        <div class="section">
+            <h2>Positions</h2>
+            <div class="form-group">
+                <div class="form-field">
+                    <label for="lookup_client">Client ID</label>
+                    <input type="number" id="lookup_client" placeholder="e.g., 1" min="1">
+                </div>
+                <button class="create" onclick="loadPositions()" style="margin-bottom: 0;">Load</button>
+            </div>
+            <div id="positions-container">
+                <p id="loading">Enter a client ID to view positions</p>
+            </div>
+        </div>
+    </div>
+    
+    <script>
+        const API_BASE = '';  // Same origin
+        
+        async function createETF() {
+            const clientId = document.getElementById('client_id').value;
+            const amount = document.getElementById('amount').value;
+            
+            if (!clientId || !amount) {
+                showResult('Please enter client ID and amount', false);
+                return;
+            }
+            
+            try {
+                const response = await fetch('/create', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({client_id: parseInt(clientId), amount: parseInt(amount)})
+                });
+                const data = await response.json();
+                showResult(data.message + ` (UNDY balance: ${data.undy_balance})`, data.success);
+                if (data.success) {
+                    loadPositions();
+                }
+            } catch (err) {
+                showResult('Error: ' + err.message, false);
+            }
+        }
+        
+        async function redeemETF() {
+            const clientId = document.getElementById('client_id').value;
+            const amount = document.getElementById('amount').value;
+            
+            if (!clientId || !amount) {
+                showResult('Please enter client ID and amount', false);
+                return;
+            }
+            
+            try {
+                const response = await fetch('/redeem', {
+                    method: 'POST',
+                    headers: {'Content-Type': 'application/json'},
+                    body: JSON.stringify({client_id: parseInt(clientId), amount: parseInt(amount)})
+                });
+                const data = await response.json();
+                showResult(data.message + ` (UNDY balance: ${data.undy_balance})`, data.success);
+                if (data.success) {
+                    loadPositions();
+                }
+            } catch (err) {
+                showResult('Error: ' + err.message, false);
+            }
+        }
+        
+        async function loadPositions() {
+            const clientId = document.getElementById('lookup_client').value || document.getElementById('client_id').value;
+            if (!clientId) return;
+            
+            document.getElementById('lookup_client').value = clientId;
+            
+            try {
+                const response = await fetch(`/positions/${clientId}`);
+                const data = await response.json();
+                
+                const container = document.getElementById('positions-container');
+                const positions = data.positions;
+                
+                // Symbol order: underlyings first, then ETF
+                const symbolOrder = ['KNAN', 'STED', 'FISH', 'DILN', 'SORN', 'RYAN', 'LYON', 'WLSH', 'LEWI', 'BDIN', 'UNDY', 'GOLD', 'BLUE'];
+                
+                let html = '<div class="positions-grid">';
+                for (const ticker of symbolOrder) {
+                    const qty = positions[ticker] || 0;
+                    const isETF = ticker === 'UNDY';
+                    const qtyClass = qty > 0 ? 'positive' : qty < 0 ? 'negative' : 'zero';
+                    
+                    html += `
+                        <div class="position-card ${isETF ? 'etf' : ''}">
+                            <div class="ticker">${ticker}</div>
+                            <div class="qty ${qtyClass}">${qty}</div>
+                        </div>
+                    `;
+                }
+                html += '</div>';
+                
+                container.innerHTML = html;
+            } catch (err) {
+                document.getElementById('positions-container').innerHTML = 
+                    '<p style="color: var(--accent-red);">Error loading positions</p>';
+            }
+        }
+        
+        function showResult(message, success) {
+            const el = document.getElementById('result');
+            el.textContent = message;
+            el.className = 'result ' + (success ? 'success' : 'error');
+        }
+    </script>
+</body>
+</html>

--- a/matching_engine/matching_engine.cpp
+++ b/matching_engine/matching_engine.cpp
@@ -40,8 +40,23 @@ int main(int argc, char** argv) {
     std::string clearing_ip = argv[3];
 
     std::vector<symbol_definition> symbols = {
-        {1, 10, 1, 1000, 10000000, 0}, // GOLD
-        {2, 5, 1, 1000, 10000000, 0}, // BLUE
+        {1, 10, 1, 1000, 10000000, 0},  // GOLD
+        {2, 5, 1, 1000, 10000000, 0},   // BLUE
+        // UNDY ETF underlying components (Notre Dame dorms)
+        // Men's dorms
+        {3, 5, 1, 1000, 10000000, 0},   // KNAN - Keenan Hall
+        {4, 5, 1, 1000, 10000000, 0},   // STED - St. Edward's Hall
+        {5, 5, 1, 1000, 10000000, 0},   // FISH - Fisher Hall
+        {6, 5, 1, 1000, 10000000, 0},   // DILN - Dillon Hall
+        {7, 5, 1, 1000, 10000000, 0},   // SORN - Sorin Hall
+        // Women's dorms
+        {8, 5, 1, 1000, 10000000, 0},   // RYAN - Ryan Hall
+        {9, 5, 1, 1000, 10000000, 0},   // LYON - Lyons Hall
+        {10, 5, 1, 1000, 10000000, 0},  // WLSH - Walsh Hall
+        {11, 5, 1, 1000, 10000000, 0},  // LEWI - Lewis Hall
+        {12, 5, 1, 1000, 10000000, 0},  // BDIN - Badin Hall
+        // ETF (1 UNDY = 1 share of each underlying)
+        {13, 10, 1, 1000, 10000000, 0}, // UNDY - Notre Dame Dorm ETF
     };
 
     constexpr int logging_core = 1;


### PR DESCRIPTION
Co-authored by: Phillip Tallmadge @philliptallmadge

## Overview

Adds an ETF (Exchange-Traded Fund) feature to NDFEX to enable arbitrage opportunities for students. This PR is based on work by @philliptallmadge

### New Symbols

| ID | Ticker | Name | Type |
|----|--------|------|------|
| 3 | KNAN | Keenan Hall | Men's dorm |
| 4 | STED | St. Edward's Hall | Men's dorm |
| 5 | FISH | Fisher Hall | Men's dorm |
| 6 | DILN | Dillon Hall | Men's dorm |
| 7 | SORN | Sorin Hall | Men's dorm |
| 8 | RYAN | Ryan Hall | Women's dorm |
| 9 | LYON | Lyons Hall | Women's dorm |
| 10 | WLSH | Walsh Hall | Women's dorm |
| 11 | LEWI | Lewis Hall | Women's dorm |
| 12 | BDIN | Badin Hall | Women's dorm |
| 13 | UNDY | Notre Dame Dorm ETF | ETF |

**1 UNDY = 1 share of each underlying dorm symbol**

### ETF Service (Python)

A new `etf_service/` component that:
- Tracks positions via clearing multicast (source of truth)
- Provides REST API for ETF create/redeem operations
- Serves WebSocket data to dashboard (can replace web_data.cpp)
- Maintains position ledger combining clearing data + ETF adjustments

### REST API

| Endpoint | Method | Description |
|----------|--------|-------------|
| `/positions/<client_id>` | GET | Get client positions |
| `/create` | POST | Create UNDY from underlyings |
| `/redeem` | POST | Redeem UNDY to underlyings |
| `/health` | GET | Health check |

### Usage

```bash
# Start with ETF service
./ndfex.sh start --with-etf

# Create ETF (client must have positions in all underlyings)
curl -X POST http://localhost:5000/create \
  -H 'Content-Type: application/json' \
  -d '{"client_id": 1, "amount": 10}'

# Redeem ETF back to underlyings
curl -X POST http://localhost:5000/redeem \
  -H 'Content-Type: application/json' \
  -d '{"client_id": 1, "amount": 5}'
```

### Web UI

Simple web interface at http://localhost:5000/ for create/redeem operations.

### Changes

- `matching_engine/matching_engine.cpp` - Added symbols 3-13
- `bots/bot_runner.cpp` - Updated to provide liquidity for all symbols
- `ndfex.sh` - Added `--with-etf` flag
- `etf_service/` - New Python service (Flask + WebSocket)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a complete ETF subsystem and extends the market with new symbols.
> 
> - **New market instruments**: Adds symbols `3-13` (dorm underlyings and `UNDY` ETF) to `matching_engine` and updates `bots` to quote/trade them (fair values, variances, stackers/takers).
> - **ETF service (Python)**: New `etf_service/` with Flask REST endpoints (`/create`, `/redeem`, `/positions`, `/health`), WebSocket feed for dashboard snapshots, and a simple web UI (`templates/etf.html`).
> - **Market/clearing clients**: `md_client.py` and `clearing_client.py` listen to multicast feeds; `position_ledger.py` combines clearing data with ETF adjustments (create/redeem) and computes per-client position snapshots.
> - **Startup integration**: `ndfex.sh` adds `--with-etf` flag to launch the ETF service and manages its PID/status.
> - **Deps**: `etf_service/requirements.txt` includes `flask` and `websockets`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b237cac72640d89a9a670a92ab4d524bc704e20. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->